### PR TITLE
feat: use qemu for cross compilation of flatcar

### DIFF
--- a/.github/workflows/build-and-deploy-nvme-tcp.yml
+++ b/.github/workflows/build-and-deploy-nvme-tcp.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Run docker-nvme-tcp.sh
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           if [ "${{ matrix.board_arch }}" = "arm64" ]; then
             echo "Building for ARM64 architecture"
@@ -56,8 +56,8 @@ jobs:
       - name: Simulate docker-nvme-tcp.sh output file
         if: github.ref != 'refs/heads/main'
         run: |
-          #mkdir -p build/kernel/nvme
-          #echo "dummy nvme tcp module" > build/kernel/nvme/nvme-tcp.ko.xz
+          mkdir -p build/kernel/nvme
+          echo "dummy nvme tcp module" > build/kernel/nvme/nvme-tcp.ko.xz
 
       - name: Find built nvme-tcp.ko.xz
         id: find_nvme

--- a/.github/workflows/build-and-deploy-nvme-tcp.yml
+++ b/.github/workflows/build-and-deploy-nvme-tcp.yml
@@ -30,7 +30,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
+        if: matrix.board_arch == 'arm64'
         uses: docker/setup-qemu-action@v3
+
+      - name: verify QEMU setup
+        if: matrix.board_arch == 'arm64'
+        run: |
+          uname -m
+          docker run --rm --platform linux/arm64 docker.io/alpine uname -m
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-and-deploy-nvme-tcp.yml
+++ b/.github/workflows/build-and-deploy-nvme-tcp.yml
@@ -32,22 +32,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: install qemu for cross-compilation
+        if: matrix.board_arch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+          cat /proc/sys/fs/binfmt_misc/qemu-aarch64 || true
+          cat /usr/lib/binfmt.d/qemu-aarch64-static.conf || true
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          if ! [ -x /usr/bin/qemu-aarch64-static ]; then
+            echo "Error: /usr/bin/qemu-aarch64-static not found. Please install qemu-user-static on your host."
+            exit 1
+          fi
+          if ! grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64; then
+            echo "Error: qemu-aarch64 binfmt_misc entry not enabled. Please register qemu-aarch64-static with binfmt_misc."
+            exit 1
+          fi
+
       - name: Run docker-nvme-tcp.sh
         #if: github.ref == 'refs/heads/main'
         run: |
           if [ "${{ matrix.board_arch }}" = "arm64" ]; then
             echo "Building for ARM64 architecture"
-            echo "Installing qemu-user-static for ARM64 cross-compilation"
-            sudo apt-get update
-            sudo apt-get install -y qemu-user-static
-            if ! [ -x /usr/bin/qemu-aarch64-static ]; then
-              echo "Error: /usr/bin/qemu-aarch64-static not found. Please install qemu-user-static on your host."
-              exit 1
-            fi
-            if ! grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64; then
-              echo "Error: qemu-aarch64 binfmt_misc entry not enabled. Please register qemu-aarch64-static with binfmt_misc."
-              exit 1
-            fi
           else
             echo "Building for AMD64 architecture"
           fi

--- a/.github/workflows/build-and-deploy-nvme-tcp.yml
+++ b/.github/workflows/build-and-deploy-nvme-tcp.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload nvme-tcp.ko.xz as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nvme-tcp-ko-xz-${{ runner.arch }}
+          name: nvme-tcp-ko-xz-${{ matrix.board_arch }}
           path: ${{ steps.find_nvme.outputs.nvme_path }}
 
   deploy:
@@ -99,8 +99,8 @@ jobs:
       - name: list built artifacts and rename
         run: |
           find ./ -name "*nvme*ko*"
-          mv ./nvme-tcp-ko-xz-X64/nvme-tcp.ko.xz ./nvme-tcp.ko.xz.amd64
-          mv ./nvme-tcp-ko-xz-ARM64/nvme-tcp.ko.xz ./nvme-tcp.ko.xz.arm64
+          mv ./nvme-tcp-ko-xz-amd64/nvme-tcp.ko.xz ./nvme-tcp.ko.xz.amd64
+          mv ./nvme-tcp-ko-xz-arm64/nvme-tcp.ko.xz ./nvme-tcp.ko.xz.arm64
           echo "Renamed artifacts"
           ls -l ./nvme-tcp.ko.xz.*
       - name: Create release and upload package with commit hash

--- a/.github/workflows/build-and-deploy-nvme-tcp.yml
+++ b/.github/workflows/build-and-deploy-nvme-tcp.yml
@@ -17,10 +17,13 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        board_arch: [amd64, arm64]
+
+    env:
+      BOARD_ARCH: ${{ matrix.board_arch }}
 
     steps:
       - name: Checkout repository
@@ -30,16 +33,32 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Run docker-nvme-tcp.sh
-        if: github.ref == 'refs/heads/main'
+        #if: github.ref == 'refs/heads/main'
         run: |
+          if [ "${{ matrix.board_arch }}" = "arm64" ]; then
+            echo "Building for ARM64 architecture"
+            echo "Installing qemu-user-static for ARM64 cross-compilation"
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
+            if ! [ -x /usr/bin/qemu-aarch64-static ]; then
+              echo "Error: /usr/bin/qemu-aarch64-static not found. Please install qemu-user-static on your host."
+              exit 1
+            fi
+            if ! grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64; then
+              echo "Error: qemu-aarch64 binfmt_misc entry not enabled. Please register qemu-aarch64-static with binfmt_misc."
+              exit 1
+            fi
+          else
+            echo "Building for AMD64 architecture"
+          fi
           chmod +x build/kernel/nvme/docker-nvme-tcp.sh
           ./build/kernel/nvme/docker-nvme-tcp.sh
 
       - name: Simulate docker-nvme-tcp.sh output file
         if: github.ref != 'refs/heads/main'
         run: |
-          mkdir -p build/kernel/nvme
-          echo "dummy nvme tcp module" > build/kernel/nvme/nvme-tcp.ko.xz
+          #mkdir -p build/kernel/nvme
+          #echo "dummy nvme tcp module" > build/kernel/nvme/nvme-tcp.ko.xz
 
       - name: Find built nvme-tcp.ko.xz
         id: find_nvme

--- a/.github/workflows/build-and-deploy-nvme-tcp.yml
+++ b/.github/workflows/build-and-deploy-nvme-tcp.yml
@@ -29,25 +29,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: install qemu for cross-compilation
-        if: matrix.board_arch == 'arm64'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-          cat /proc/sys/fs/binfmt_misc/qemu-aarch64 || true
-          cat /usr/lib/binfmt.d/qemu-aarch64-static.conf || true
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          if ! [ -x /usr/bin/qemu-aarch64-static ]; then
-            echo "Error: /usr/bin/qemu-aarch64-static not found. Please install qemu-user-static on your host."
-            exit 1
-          fi
-          if ! grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64; then
-            echo "Error: qemu-aarch64 binfmt_misc entry not enabled. Please register qemu-aarch64-static with binfmt_misc."
-            exit 1
-          fi
 
       - name: Run docker-nvme-tcp.sh
         #if: github.ref == 'refs/heads/main'

--- a/.github/workflows/poll-flatcar-scripts-tags.yml
+++ b/.github/workflows/poll-flatcar-scripts-tags.yml
@@ -46,7 +46,7 @@ jobs:
           echo "NEW_RELEASES=$new_releases"
 
       - name: Trigger downstream workflow for each new release
-        if: steps.find_new.outputs.new_releases != ''
+        if: steps.find_new.outputs.new_releases != '' && github.ref == 'refs/heads/main'
         run: |
           grep '^stable-' new_releases.txt | while IFS= read -r release; do
             echo "Triggering workflow for release: $release"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,20 @@ I have also created a [poll-flatcar-scripts-tags.yml](.github/workflows/poll-fla
 
 ### Setup flatcar to automatically download and install the NVMe-TCP kernel module
 
+#### install script
+
+1. Download the install script from [install-nvme-tcp-kernel-module.sh](scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh) to /opt/install-nvme-tcp-kernel-module.sh.
+2. Make the script executable: `chmod +x /opt/install-nvme-tcp-kernel-module.sh`
+3. Run the script to download and install the NVMe-TCP kernel module: `sudo /opt/install-nvme-tcp-kernel-module.sh`
+
+#### systemd service
+
 1. Create a systemd service file for the NVMe-TCP kernel module.
 2. Enable the service to start on boot.
-3. Start the service to download and install the module.
+3. The service will automatically download and install the module on system startup.
+
+For simplicity, I have automated the setup of the systemd service in a bash script. Check the [create-nvme-tcp-systemd-service.sh](scripts/install-nvme-tcp/create-nvme-tcp-systemd-service.sh) script for details.
+Run the script after downloading and installing the install script to set up the systemd service.
 
 ## The .iso file
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,132 @@
-# k3s on flatcar linux
+# k3s on Flatcar Linux
 
-This project is intended as reference for a k3s installation on Flatcar Linux. The generated .iso file can be used to setup VMs or Bare Metal Machines.
+This project provides a reference implementation for installing [k3s](https://k3s.io/) (a lightweight Kubernetes distribution) on [Flatcar Linux](https://www.flatcar.org/). It automates the process of building and deploying the NVMe-TCP kernel module, and generates a ready-to-use ISO for VM or bare metal installation.
+
+---
+
+## Table of Contents
+
+- [Project Overview](#project-overview)
+- [Scripts](#scripts)
+- [Building Kernel Modules](#building-kernel-modules)
+- [Automated Workflows](#automated-workflows)
+- [Installation & Usage](#installation--usage)
+- [Troubleshooting](#troubleshooting)
+- [License](#license)
+- [Contributing](#contributing)
+
+---
+
+## Project Overview
+
+This repository helps you:
+
+- Build and deploy the NVMe-TCP kernel module for Flatcar Linux (required for storage solutions like OpenEBS or Rancher Longhorn).
+- Generate an ISO image with pre-configured ignition files for Flatcar and k3s.
+- Automate installation and setup using scripts and GitHub Actions workflows.
 
 ## Scripts
 
-- [scripts/convert-to-json-ignition.sh](scripts/convert-to-json-ignition.sh) - Converts the yaml butane config to json ignition config.
-- [scripts/generate-config-iso.sh](scripts/generate-config-iso.sh) - Generates an ISO image with the ignition config. Can be used for setup on bare metal or when the common provision approach is not available.
-- [scripts/server-2-install.sh](scripts/server-2-install.sh) - Installs the second k3s server on a Flatcar Linux node.
+- [`scripts/convert-to-json-ignition.sh`](scripts/convert-to-json-ignition.sh): Converts YAML Butane config to JSON Ignition config.
+- [`scripts/generate-config-iso.sh`](scripts/generate-config-iso.sh): Generates an ISO image with the ignition config for bare metal or VM setup.
+- [`scripts/server-2-install.sh`](scripts/server-2-install.sh): Installs the second k3s server on a Flatcar Linux node.
+- [`scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh`](scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh): Installs the NVMe-TCP kernel module.
+- [`scripts/install-nvme-tcp/create-nvme-tcp-systemd-service.sh`](scripts/install-nvme-tcp/create-nvme-tcp-systemd-service.sh): Sets up a systemd service for automatic module installation.
+
+---
 
 ## Building Kernel Modules
 
-For some storage solutions like OpenEBS or Rancher Longhorn the nvme tcp kernel module is required but not included with flatcar linux by default.
-Therefore, it needs to be built and deployed separately. The flatcar linux documentation provides guidance on how to do this. Unfortunately for the nvme tcp kernel module, the process is not as straightforward as it could be. I was not able to find a clear step-by-step guide for this specific module.
-In my experience the best way to build and deploy the nvme tcp kernel module is building flatcar linux from source with the flatcar SDK container. Kernel module settings can be changed before building the kernel and other dependencies. After a complete build the kernel module can be found in the default kernel module path within the SDK container.
+Some storage solutions (e.g., OpenEBS, Rancher Longhorn) require the NVMe-TCP kernel module, which is not included in Flatcar Linux by default. This project provides scripts and workflows to automate building and deploying this module.
 
-### Building the Kernel Module
+### Manual Build Steps
 
-1. Set up the Flatcar SDK container.
-2. Modify the kernel module settings as needed.
+1. Set up the [Flatcar SDK container](https://docs.flatcar.org/developers/sdk/).
+2. Modify kernel module settings as needed.
 3. Build the kernel and the module.
 4. Locate the built `nvme-tcp.ko.xz` file in the SDK container.
 
-### Github Actions Workflow for NVMe-TCP Kernel Module
+---
 
-To make the process of building and deploying the nvme tcp kernel module easier, I have used a Github Actions workflow. This workflow automates the steps required to build the module and create a release.
+## Automated Workflows
 
-Check the [build-and-deploy-nvme-tcp.yml](.github/workflows/build-and-deploy-nvme-tcp.yml) file for the workflow definition.
-I have also created a [poll-flatcar-scripts-tags.yml](.github/workflows/poll-flatcar-scripts-tags.yml) workflow for polling the Flatcar scripts repository for new releases. All new releases are automatically built and deployed using the NVMe-TCP kernel module workflow.
+GitHub Actions are used to automate building and deploying the NVMe-TCP kernel module:
 
-### Setup flatcar to automatically download and install the NVMe-TCP kernel module
+- [`build-and-deploy-nvme-tcp.yml`](.github/workflows/build-and-deploy-nvme-tcp.yml): Builds the module and creates a release.
+- [`poll-flatcar-scripts-tags.yml`](.github/workflows/poll-flatcar-scripts-tags.yml): Polls the Flatcar scripts repository for new releases and triggers builds.
 
-#### install script
+---
 
-1. Download the install script from [install-nvme-tcp-kernel-module.sh](scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh) to /opt/install-nvme-tcp-kernel-module.sh.
-2. Make the script executable: `chmod +x /opt/install-nvme-tcp-kernel-module.sh`
-3. Run the script to download and install the NVMe-TCP kernel module: `sudo /opt/install-nvme-tcp-kernel-module.sh`
+## Installation & Usage
 
-#### systemd service
+### 1. Generate the ISO
 
-1. Create a systemd service file for the NVMe-TCP kernel module.
-2. Enable the service to start on boot.
-3. The service will automatically download and install the module on system startup.
+```sh
+# Convert Butane YAML to Ignition JSON
+./scripts/convert-to-json-ignition.sh <input.yaml> <output.json>
 
-For simplicity, I have automated the setup of the systemd service in a bash script. Check the [create-nvme-tcp-systemd-service.sh](scripts/install-nvme-tcp/create-nvme-tcp-systemd-service.sh) script for details.
-Run the script after downloading and installing the install script to set up the systemd service.
+# Generate the ISO image
+./scripts/generate-config-iso.sh <ignition.json>
+```
 
-## The .iso file
+The generated ISO can be used to install Flatcar and k3s on your target machine.
 
-The iso file is intended to be used for installation of flatcar and k3s. First you need to boot from the flatcar iso file.
-The generated iso file contains ready to use configuration which can be used for easy configuration of flatcar and k3s.
+---
+
+### 2. Install flatcar with k3s
+
+Boot from the generated ISO and follow the flatcar documentation instructions to install Flatcar. The k3s installation will be handled automatically by the ignition file.
+
+### 3. Install the NVMe-TCP Kernel Module
+
+If flatcar was installed successfully, you can now install the NVMe-TCP kernel module.
+
+```sh
+# Download the install script
+curl -o /opt/install-nvme-tcp-kernel-module.sh \
+	https://raw.githubusercontent.com/csautter/k3s-flatcar/scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh
+
+# Make it executable
+chmod +x /opt/install-nvme-tcp-kernel-module.sh
+
+# Run the script (as root)
+sudo /opt/install-nvme-tcp-kernel-module.sh
+```
+
+### 4. Set Up the Systemd Service
+
+```sh
+# Download the service setup script
+curl -o /opt/create-nvme-tcp-systemd-service.sh \
+    https://raw.githubusercontent.com/csautter/k3s-flatcar/scripts/install-nvme-tcp/create-nvme-tcp-systemd-service.sh
+
+# Make it executable
+chmod +x /opt/create-nvme-tcp-systemd-service.sh
+
+# Run the setup script to create and enable the systemd service
+sudo bash /opt/create-nvme-tcp-systemd-service.sh
+```
+
+This will ensure the NVMe-TCP kernel module is automatically installed on boot.
+
+## Troubleshooting
+
+- **Kernel module not loading?**
+  - Check `dmesg` and `lsmod | grep nvme` for errors.
+  - Ensure the kernel version matches the module version.
+- **Systemd service not starting?**
+  - Run `systemctl status nvme-tcp-install.service` for logs.
+- **ISO not booting?**
+  - Verify the ISO was generated correctly and matches your hardware requirements.
+
+---
+
+## License
+
+This project is licensed under the terms of the [MIT License](LICENSE).
+
+---
+
+## Contributing
+
+Contributions are welcome! Please open issues or submit pull requests for improvements, bug fixes, or new features.

--- a/build/kernel/nvme/docker-nvme-tcp.sh
+++ b/build/kernel/nvme/docker-nvme-tcp.sh
@@ -20,8 +20,8 @@ echo "CONFIG_NVME_TCP=m" >> ~/trunk/src/third_party/coreos-overlay/sys-kernel/co
 
 # consider architecture
 if [ -n "${BOARD_ARCH}" ] && [ "${BOARD_ARCH}" = "arm64" ]; then
-  ./build_packages --board=arm64
-  ./build_image --board=arm64
+  ./build_packages --board=arm64-usr
+  ./build_image --board=arm64-usr
   ARCHITECTURE=arm64
 else
   ./build_packages
@@ -30,7 +30,7 @@ else
 fi
 
 sudo find /build/ -name "*nvme*ko*"
-mkdir -p /opt/kernel-modules/${BOARD_ARCH:-amd64}
+sudo mkdir -p /opt/kernel-modules/${BOARD_ARCH:-amd64}
 sudo cp -r /build/*-usr/usr/lib/modules/*-flatcar/kernel/drivers/nvme/ /opt/kernel-modules/${BOARD_ARCH:-amd64}/
 EOF
 container_id=$(docker ps -l -q)

--- a/build/kernel/nvme/docker-nvme-tcp.sh
+++ b/build/kernel/nvme/docker-nvme-tcp.sh
@@ -20,15 +20,6 @@ echo "CONFIG_NVME_TCP=m" >> ~/trunk/src/third_party/coreos-overlay/sys-kernel/co
 
 # consider architecture
 if [ -n "${BOARD_ARCH}" ] && [ "${BOARD_ARCH}" = "arm64" ]; then
-  # Ensure qemu-aarch64-static is available for cross-compilation
-  if ! [ -x /usr/bin/qemu-aarch64-static ]; then
-    echo "Error: /usr/bin/qemu-aarch64-static not found. Please install qemu-user-static on your host."
-    exit 1
-  fi
-  if ! grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64; then
-    echo "Error: qemu-aarch64 binfmt_misc entry not enabled. Please register qemu-aarch64-static with binfmt_misc."
-    exit 1
-  fi
   ./build_packages --board=arm64
   ./build_image --board=arm64
   ARCHITECTURE=arm64

--- a/build/kernel/nvme/docker-nvme-tcp.sh
+++ b/build/kernel/nvme/docker-nvme-tcp.sh
@@ -19,7 +19,16 @@ echo "CONFIG_NVME_TARGET_TCP=m" >> ~/trunk/src/third_party/coreos-overlay/sys-ke
 echo "CONFIG_NVME_TCP=m" >> ~/trunk/src/third_party/coreos-overlay/sys-kernel/coreos-modules/files/commonconfig-*
 
 # consider architecture
-if [ "$(uname -m)" = "aarch64" ]; then
+if [ -n "${BOARD_ARCH}" ] && [ "${BOARD_ARCH}" = "arm64" ]; then
+  # Ensure qemu-aarch64-static is available for cross-compilation
+  if ! [ -x /usr/bin/qemu-aarch64-static ]; then
+    echo "Error: /usr/bin/qemu-aarch64-static not found. Please install qemu-user-static on your host."
+    exit 1
+  fi
+  if ! grep -q enabled /proc/sys/fs/binfmt_misc/qemu-aarch64; then
+    echo "Error: qemu-aarch64 binfmt_misc entry not enabled. Please register qemu-aarch64-static with binfmt_misc."
+    exit 1
+  fi
   ./build_packages --board=arm64
   ./build_image --board=arm64
   ARCHITECTURE=arm64
@@ -30,8 +39,8 @@ else
 fi
 
 sudo find /build/ -name "*nvme*ko*"
-mkdir -p /opt/kernel-modules/${ARCHITECTURE:-amd64}
-sudo cp -r /build/*-usr/usr/lib/modules/*-flatcar/kernel/drivers/nvme/ /opt/kernel-modules/${ARCHITECTURE:-amd64}/
+mkdir -p /opt/kernel-modules/${BOARD_ARCH:-amd64}
+sudo cp -r /build/*-usr/usr/lib/modules/*-flatcar/kernel/drivers/nvme/ /opt/kernel-modules/${BOARD_ARCH:-amd64}/
 EOF
 container_id=$(docker ps -l -q)
 echo "Container ID: $container_id"

--- a/scripts/install-nvme-tcp/create-nvme-tcp-systemd-service.sh
+++ b/scripts/install-nvme-tcp/create-nvme-tcp-systemd-service.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euox pipefail
+
+function create_systemd_usr_lib_modules_mount {
+    modules=/opt/modules
+    sudo mkdir -p "${modules}" "${modules}.wd"
+    echo "Creating systemd mount unit for /usr/lib/modules overlay..."
+    cat << EOF | sudo tee /etc/systemd/system/usr-lib-modules.mount
+[Unit]
+Description=Custom Kernel Modules
+Before=local-fs.target
+ConditionPathExists=/opt/modules
+
+[Mount]
+Type=overlay
+What=overlay
+Where=/usr/lib/modules
+Options=lowerdir=/usr/lib/modules,upperdir=/opt/modules,workdir=/opt/modules.wd
+
+[Install]
+WantedBy=local-fs.target
+EOF
+    sudo systemctl enable --now usr-lib-modules.mount
+}
+
+if [ ! -f /etc/systemd/system/usr-lib-modules.mount ]; then
+    create_systemd_usr_lib_modules_mount
+fi
+
+function create_systemd_install_nvme_tcp_service {
+    SERVICE_NAME="install-nvme-tcp-kernel-modules.service"
+    SCRIPT_PATH="/opt/install-nvme-tcp-kernel-modules.sh"
+    if [ ! -f "$SCRIPT_PATH" ]; then
+        echo "Error: $SCRIPT_PATH not found!"
+        exit 1
+    fi
+    echo "Creating systemd service to install NVMe-TCP kernel modules..."
+    cat <<EOF | sudo tee /etc/systemd/system/$SERVICE_NAME
+[Unit]
+Description=Install NVMe-TCP Kernel Modules
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=$SCRIPT_PATH
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    sudo systemctl enable --now $SERVICE_NAME
+}
+
+if [ ! -f /etc/systemd/system/install-nvme-tcp-kernel-modules.service ]; then
+    create_systemd_install_nvme_tcp_service
+fi

--- a/scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh
+++ b/scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# install-nvme-tcp-kernel-module.sh
+# Installs the nvme-tcp kernel module matching the current Flatcar release.
+
+set -euo pipefail
+
+REPO="csautter/k3s-flatcar"
+MODULE_NAME="nvme-tcp"
+ARCH="$(uname -m)"
+if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ]; then
+    ARCH="arm64"
+fi
+
+# Get current Flatcar version
+FLATCAR_VERSION=$(cat /etc/os-release | grep VERSION | cut -d= -f2 | tr -d '"')
+FLATCAR_BUILD_ID=$(cat /etc/os-release | grep BUILD_ID | cut -d= -f2 | tr -d '"')
+echo "Current Flatcar version: $FLATCAR_VERSION-$FLATCAR_BUILD_ID"
+
+TAG="${MODULE_NAME}-${ARCH}-stable-${FLATCAR_VERSION}"
+
+# Download URL for the kernel module
+MODULE_URL="https://github.com/${REPO}/releases/download/${TAG}/${MODULE_NAME}.ko.xz"
+
+MODULE_DIR="/opt/nvme-tcp"
+MODULE_PATH="${MODULE_DIR}/${MODULE_NAME}.ko.xz"
+
+# Create directory for the module
+mkdir -p "${MODULE_DIR}"
+
+# Download the kernel module if not present or outdated
+if [ ! -f "${MODULE_PATH}" ]; then
+    echo "Downloading nvme-tcp kernel module for Flatcar ${FLATCAR_VERSION}-${FLATCAR_BUILD_ID}..."
+    curl -fsSL -o "${MODULE_PATH}" "${MODULE_URL}"
+fi
+
+# Install the module to /lib/modules/$(uname -r)/extra
+# /usr/lib/modules/6.6.100-flatcar/kernel/drivers/nvme/target/host/
+INSTALL_DIR="/usr/lib/modules/$(uname -r)/extra"
+mkdir -p "${INSTALL_DIR}"
+cp -f "${MODULE_PATH}" "${INSTALL_DIR}/"
+
+# Update module dependencies
+depmod
+
+# Load the module
+modprobe nvme-tcp
+
+# Enable module to load at boot
+echo "nvme-tcp" > /etc/modules-load.d/nvme-tcp.conf
+
+echo "nvme-tcp kernel module installed and loaded."

--- a/scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh
+++ b/scripts/install-nvme-tcp/install-nvme-tcp-kernel-module.sh
@@ -36,7 +36,6 @@ if [ ! -f "${MODULE_PATH}" ]; then
 fi
 
 # Install the module to /lib/modules/$(uname -r)/extra
-# /usr/lib/modules/6.6.100-flatcar/kernel/drivers/nvme/target/host/
 INSTALL_DIR="/usr/lib/modules/$(uname -r)/extra"
 mkdir -p "${INSTALL_DIR}"
 cp -f "${MODULE_PATH}" "${INSTALL_DIR}/"


### PR DESCRIPTION
The flatcar sdk container is just available as amd64 image, therefore it can just build arm64 architecture with cross compilation based on qemu.

Scope:
- configuring qemu in a way that it supports the successful cross compilation of nvme tcp kernel module